### PR TITLE
didOpen, didClose, didChange

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -1,13 +1,21 @@
 package com.ossuminc.riddl.lsp.server
 
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams}
+import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, TextDocumentContentChangeEvent}
 import org.eclipse.lsp4j.services.TextDocumentService
 
 import java.util
 import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.*
+
+case class RiddlCodeDoc(textString: String = "")
+
+object RiddlCodeDoc {
+}
 
 class RiddlLSPTextDocumentService extends TextDocumentService {
+  private var riddlDoc: RiddlCodeDoc = RiddlCodeDoc()
+  private val unsavedChanges: Seq[TextDocumentContentChangeEvent] = Seq()
 
   override def completion(position: CompletionParams):
     CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] = {
@@ -18,11 +26,17 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
       }
     )
   }
-  override def didOpen(params: DidOpenTextDocumentParams): Unit = ???
+  override def didOpen(params: DidOpenTextDocumentParams): Unit = {
+    riddlDoc = RiddlCodeDoc(params.getTextDocument.getText)
+  }
 
-  override def didChange(params: DidChangeTextDocumentParams): Unit = ???
+  override def didChange(params: DidChangeTextDocumentParams): Unit = {
+    unsavedChanges ++ params.getContentChanges.asScala
+  }
 
-  override def didClose(params: DidCloseTextDocumentParams): Unit = ???
+  override def didClose(params: DidCloseTextDocumentParams): Unit = {
+    riddlDoc = RiddlCodeDoc()
+  }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = ???
 }


### PR DESCRIPTION
By implementing didOpen and didClose functions, we can pull in a text string representing a riddl document

didChange was implemented because it is simple & part of same milestone.
didSave is more complex - requires insight into how changes are meant to be synchronised with the riddl doc string.

Next Steps:
- didSave
- analyze doc string as Riddl DSL