### PR TITLE
`did` functions [OTOT 10-14]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 3.8.1
+runner.dialect = scala3

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,11 +8,9 @@ object V {
   val pureconfig = "0.17.6"
   val scalacheck = "1.17.0"
   val scalatest = "3.2.18"
-  val mockito = "1.17.31"
   val scopt = "4.1.0"
   val slf4j = "2.0.4"
   val lsp4j = "0.22.0"
-  val reactificRiddl = "0.27.5"
   val ossumRiddl = "0.42.0"
 }
 
@@ -22,15 +20,14 @@ object Dep {
   val scalactic = "org.scalactic" %% "scalactic" % V.scalatest
   val scalatest = "org.scalatest" %% "scalatest" % V.scalatest
   val scalacheck = "org.scalacheck" %% "scalacheck" % V.scalacheck
-  val mockito = "org.mockito" %% "mockito-scala" % V.mockito
   val scopt = "com.github.scopt" %% "scopt" % V.scopt
   val slf4j = "org.slf4j" % "slf4j-nop" % V.slf4j
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % V.lsp4j
-  val riddlc = "com.reactific" %% "riddlc" % V.reactificRiddl
+  val riddlc = "com.ossuminc" %% "riddlc" % V.ossumRiddl
   val riddlTestkit = "com.ossuminc" %% "riddl-testkit" % V.ossumRiddl
   val riddlHugo = "com.ossuminc" %% "riddl-hugo" % V.ossumRiddl % "test"
 
   val basic: Seq[ModuleID] = Seq(scalactic, scalatest, scalacheck, riddlTestkit, riddlc)
 
-  val testing: Seq[ModuleID] = Seq(scalactic % "test", scalatest % "test", scalacheck % "test", mockito % "test")
+  val testing: Seq[ModuleID] = Seq(scalactic % "test", scalatest % "test", scalacheck % "test")
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,8 @@ object V {
   val scopt = "4.1.0"
   val slf4j = "2.0.4"
   val lsp4j = "0.22.0"
-  val riddl = "0.42.0"
+  val reactificRiddl = "0.27.5"
+  val ossumRiddl = "0.42.0"
 }
 
 object Dep {
@@ -23,9 +24,9 @@ object Dep {
   val scopt = "com.github.scopt" %% "scopt" % V.scopt
   val slf4j = "org.slf4j" % "slf4j-nop" % V.slf4j
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % V.lsp4j
-  val riddlc = "com.ossuminc" %% "riddlc" % V.riddl
-  val riddlTestkit = "com.ossuminc" %% "riddl-testkit" % V.riddl
-  val riddlHugo = "com.ossuminc" %% "riddl-hugo" % V.riddl % "test"
+  val riddlc = "com.reactific" %% "riddlc" % V.reactificRiddl
+  val riddlTestkit = "com.ossuminc" %% "riddl-testkit" % V.ossumRiddl
+  val riddlHugo = "com.ossuminc" %% "riddl-hugo" % V.ossumRiddl % "test"
 
   val basic: Seq[ModuleID] = Seq(scalactic, scalatest, scalacheck, riddlTestkit, riddlc)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object V {
   val pureconfig = "0.17.6"
   val scalacheck = "1.17.0"
   val scalatest = "3.2.18"
+  val mockito = "1.17.31"
   val scopt = "4.1.0"
   val slf4j = "2.0.4"
   val lsp4j = "0.22.0"
@@ -21,6 +22,7 @@ object Dep {
   val scalactic = "org.scalactic" %% "scalactic" % V.scalatest
   val scalatest = "org.scalatest" %% "scalatest" % V.scalatest
   val scalacheck = "org.scalacheck" %% "scalacheck" % V.scalacheck
+  val mockito = "org.mockito" %% "mockito-scala" % V.mockito
   val scopt = "com.github.scopt" %% "scopt" % V.scopt
   val slf4j = "org.slf4j" % "slf4j-nop" % V.slf4j
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % V.lsp4j
@@ -30,5 +32,5 @@ object Dep {
 
   val basic: Seq[ModuleID] = Seq(scalactic, scalatest, scalacheck, riddlTestkit, riddlc)
 
-  val testing: Seq[ModuleID] = Seq(scalactic % "test", scalatest % "test", scalacheck % "test")
+  val testing: Seq[ModuleID] = Seq(scalactic % "test", scalatest % "test", scalacheck % "test", mockito % "test")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.9.5")
 addSbtPlugin("com.ossuminc" % "sbt-riddl" % "0.42.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 // This enables sbt-bloop to create bloop config files for Metals editors
 // Uncomment locally if you use metals, otherwise don't slow down other

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -12,6 +12,7 @@ import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
 import org.eclipse.lsp4j.{
   CompletionItem,
+  CompletionItemKind,
   CompletionList,
   CompletionParams,
   DidChangeTextDocumentParams,
@@ -56,9 +57,9 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
       else Seq()
   }
 
-  private def updateParsedDoc(fromString: Boolean = false): Unit = {
-    if fromString then docAST = riddlDoc.map(parseDocFromString)
-    else docAST = docURI.map(parseDocFromSource)
+  private def updateParsedDoc(fromURL: Boolean = true): Unit = {
+    if fromURL then docAST = docURI.map(parseDocFromSource)
+    else docAST = riddlDoc.map(parseDocFromString)
 
     updateDocLines()
   }
@@ -126,11 +127,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
 
     completionList.setItems(
       selectedItem
-        .map(msg => {
-          val item = new CompletionItem()
-          item.setTextEditText(msg.message)
-          item
-        })
+        .map(msgToCompletion)
         .asJava
     )
     Some(
@@ -138,6 +135,12 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
         completionList
       )
     )
+  }
+
+  private def msgToCompletion(msg: Messages.Message): CompletionItem = {
+    val item = new CompletionItem()
+    item.setTextEditText(msg.message)
+    item
   }
 
   override def didOpen(params: DidOpenTextDocumentParams): Unit = {

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -1,13 +1,21 @@
 package com.ossuminc.riddl.lsp.server
 
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams}
+import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, TextDocumentContentChangeEvent}
 import org.eclipse.lsp4j.services.TextDocumentService
 
 import java.util
 import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.*
+
+case class RiddlCodeDoc(textString: String = "")
+
+object RiddlCodeDoc {
+}
 
 class RiddlLSPTextDocumentService extends TextDocumentService {
+  private var riddlDoc: RiddlCodeDoc = RiddlCodeDoc()
+  private val unsavedChanges: Seq[TextDocumentContentChangeEvent] = Seq()
 
   override def completion(position: CompletionParams):
     CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] = {
@@ -18,11 +26,17 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
       }
     )
   }
-  override def didOpen(params: DidOpenTextDocumentParams): Unit = ???
+  override def didOpen(params: DidOpenTextDocumentParams): Unit = {
+    riddlDoc = RiddlCodeDoc(params.getTextDocument.getText)
+  }
 
-  override def didChange(params: DidChangeTextDocumentParams): Unit = ???
+  override def didChange(params: DidChangeTextDocumentParams): Unit = {
+    unsavedChanges ++ params.getContentChanges.asScala
+  }
 
-  override def didClose(params: DidCloseTextDocumentParams): Unit = ???
+  override def didClose(params: DidCloseTextDocumentParams): Unit = {
+    riddlDoc = RiddlCodeDoc()
+  }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = ???
 }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -1,21 +1,36 @@
 package com.ossuminc.riddl.lsp.server
 
+import com.ossuminc.riddl.language.AST
+import com.ossuminc.riddl.language.Messages.Messages
+import com.ossuminc.riddl.language.parsing.{SourceParserInput, StringParserInput, TopLevelParser}
+import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, TextDocumentContentChangeEvent}
+import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, Position, TextDocumentContentChangeEvent}
 import org.eclipse.lsp4j.services.TextDocumentService
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import java.util
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters.*
 
-case class RiddlCodeDoc(textString: String = "")
-
-object RiddlCodeDoc {
+def parseDocFromSource(docURI: String): Either[Messages, AST.Root] = {
+  val riddlRootURI = docURI.split("/riddl/").drop(-1).mkString + "riddl/"
+  val riddlRootDoc = io.Source.fromURL(riddlRootURI)
+  new TopLevelParser(SourceParserInput(riddlRootDoc, docURI)).parseRoot()
 }
 
+def parseDocFromString(docString: String): Either[Messages, AST.Root] =
+  new TopLevelParser(StringParserInput(docString)).parseRoot()
+
 class RiddlLSPTextDocumentService extends TextDocumentService {
-  private var riddlDoc: RiddlCodeDoc = RiddlCodeDoc()
-  private val unsavedChanges: Seq[TextDocumentContentChangeEvent] = Seq()
+  private var docURI: Option[String] = None
+  private var riddlDoc: Option[String] = None
+  private var parsedDoc: Option[Either[Messages, AST.Root]] = None
+
+  def updateParsedDoc(fromURI: Boolean = true): Unit = {
+    if fromURI then parsedDoc = docURI.map(parseDocFromSource)
+    else parsedDoc = riddlDoc.map(parseDocFromString)
+  }
 
   override def completion(position: CompletionParams):
     CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] = {
@@ -27,16 +42,49 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     )
   }
   override def didOpen(params: DidOpenTextDocumentParams): Unit = {
-    riddlDoc = RiddlCodeDoc(params.getTextDocument.getText)
+    riddlDoc = Some(params.getTextDocument.getText)
+    docURI = Some(params.getTextDocument.getUri)
+    updateParsedDoc()
   }
 
   override def didChange(params: DidChangeTextDocumentParams): Unit = {
-    unsavedChanges ++ params.getContentChanges.asScala
+    def patchLine(line: String, range: lsp4j.Range, text: String) = line.patch(
+      range.getStart.getCharacter,
+      text,
+      range.getEnd.getCharacter - range.getStart.getCharacter
+    )
+
+    val changes: Seq[TextDocumentContentChangeEvent] = params.getContentChanges.asScala.toSeq
+
+    riddlDoc = riddlDoc.map(doc =>
+      var docLines: Seq[String] = doc.linesIterator.toSeq
+      changes.foreach(change => {
+        val changeRangeStart: Position = change.getRange.getStart
+        val changeRangeEnd: Position = change.getRange.getEnd
+        val changesToPatch: Seq[String] = docLines.slice(
+          changeRangeStart.getLine,
+          changeRangeEnd.getLine
+        )
+        val changeLines = change.getText.linesIterator.toSeq
+        val startLinePatch: String = patchLine(docLines.head, changes.head.getRange, changeLines.head)
+        val middlePatch: Seq[String] = changeLines.slice(1, -1)
+        val endLinePatch: String = patchLine(docLines.last, changes.last.getRange, changeLines.last)
+        docLines = docLines.patch(
+          changeRangeStart.getLine,
+          startLinePatch +: middlePatch :+ endLinePatch,
+          changeRangeEnd.getLine - changeRangeStart.getLine
+        )
+      })
+      docLines.mkString
+    )
   }
 
   override def didClose(params: DidCloseTextDocumentParams): Unit = {
-    riddlDoc = RiddlCodeDoc()
+    riddlDoc = None
+    updateParsedDoc()
   }
 
-  override def didSave(params: DidSaveTextDocumentParams): Unit = ???
+  override def didSave(params: DidSaveTextDocumentParams): Unit = {
+    parsedDoc = parsedDoc.map(_ => parseDocFromSource(params.getTextDocument.getUri))
+  }
 }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -89,7 +89,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
 
   override def didClose(params: DidCloseTextDocumentParams): Unit = {
     riddlDoc = None
-    updateParsedDoc()
+    updateParsedDoc(false)
   }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = {

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -61,6 +61,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
   override def didOpen(params: DidOpenTextDocumentParams): Unit = {
     riddlDoc = Some(params.getTextDocument.getText)
     docURI = Some(params.getTextDocument.getUri)
+    updateParsedDoc()
   }
 
   override def didChange(params: DidChangeTextDocumentParams): Unit = {
@@ -95,10 +96,12 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
       else docLines = Seq(changes.map(_.getText).mkString("\n"))
       docLines.mkString
     )
+    updateParsedDoc()
   }
 
   override def didClose(params: DidCloseTextDocumentParams): Unit = {
     riddlDoc = None
+    updateParsedDoc()
   }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = {

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -1,18 +1,35 @@
 package com.ossuminc.riddl.lsp.server
 
-import com.ossuminc.riddl.language.AST
+import com.ossuminc.riddl.language.{AST, Messages}
 import com.ossuminc.riddl.language.Messages.Messages
-import com.ossuminc.riddl.language.parsing.{SourceParserInput, StringParserInput, TopLevelParser}
+import com.ossuminc.riddl.language.parsing.{
+  SourceParserInput,
+  StringParserInput,
+  TopLevelParser
+}
+import com.ossuminc.riddl.lsp.utils.implicits.*
 import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{CompletionItem, CompletionList, CompletionParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, Position, TextDocumentContentChangeEvent}
+import org.eclipse.lsp4j.{
+  CompletionItem,
+  CompletionList,
+  CompletionParams,
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+  Position
+}
 import org.eclipse.lsp4j.services.TextDocumentService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import java.util
 import java.util.concurrent.CompletableFuture
+import scala.concurrent.Future
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
+import scala.jdk.FutureConverters.*
+import scala.xml.include.UnavailableResourceException
 
 def getRootFromUri(uri: String) = {
   uri.split("/riddl/").drop(-1).mkString + "riddl/"
@@ -29,11 +46,21 @@ def parseDocFromString(docString: String): Either[Messages, AST.Root] =
 class RiddlLSPTextDocumentService extends TextDocumentService {
   private var docURI: Option[String] = None
   private var riddlDoc: Option[String] = None
-  private var parsedDoc: Option[Either[Messages, AST.Root]] = None
+  private var docLines: Seq[String] = Seq()
+  private var docAST: Option[Either[Messages, AST.Root]] = None
+
+  // Updating Vars
+  private def updateDocLines(): Unit = {
+    docLines =
+      if riddlDoc.isDefined then riddlDoc.getOrElse("").getLinesFromText
+      else Seq()
+  }
 
   private def updateParsedDoc(fromURI: Boolean = true): Unit = {
-    if fromURI then parsedDoc = riddlDoc.map(parseDocFromString)
-    else parsedDoc = docURI.map(parseDocFromSource)
+    if fromURI then docAST = riddlDoc.map(parseDocFromString)
+    else docAST = docURI.map(parseDocFromSource)
+
+    updateDocLines()
   }
 
   private def updateRIDDLDocFromURI(): Unit = docURI.foreach(uri => {
@@ -41,21 +68,82 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     lazy val data: String =
       try {
         source.mkString
-      }
-      finally {
+      } finally {
         source.close()
       }
     riddlDoc = if data.nonEmpty then Some(data) else None
   })
 
-  override def completion(position: CompletionParams):
-    CompletableFuture[messages.Either[util.List[CompletionItem], CompletionList]] = {
-      CompletableFuture.supplyAsync(() => {
-        org.eclipse.lsp4j.jsonrpc.messages.Either.forLeft(
-          java.util.List.of()
+  // Functionality
+  override def completion(position: CompletionParams): CompletableFuture[
+    messages.Either[util.List[CompletionItem], CompletionList]
+  ] = {
+    val ast: Either[Messages, AST.Root] =
+      if !docURI.contains(position.getTextDocument.getUri) then
+        parseDocFromSource(position.getTextDocument.getUri)
+      else docAST.getOrElse(Right(AST.Root()))
+
+    if ast.isRight
+    then
+      Future.failed(UnavailableResourceException()).asJava.toCompletableFuture
+    else {
+      val completionsOpt = getCompletionFromAST(
+        position.getPosition.getLine,
+        position.getPosition.getCharacter
+      )
+      if completionsOpt.isDefined then
+        Future
+          .successful(
+            completionsOpt.getOrElse(messages.Either.forLeft(Seq().asJava))
+          )
+          .asJava
+          .toCompletableFuture
+      else Future.failed(Throwable()).asJava.toCompletableFuture
+    }
+  }
+
+  private def getCompletionFromAST(
+      line: Int,
+      charPosition: Int
+  ): Option[messages.Either[util.List[CompletionItem], CompletionList]] = {
+    var completions = CompletionList()
+    if docAST.isDefined then
+      if docAST.exists(_.isRight) then None
+      else {
+        docAST.map(
+          _.fold(
+            msgs => {
+              val completionList = new CompletionList()
+              val grouped = msgs
+                .groupBy(msg => msg.loc.line)
+              val lineItems =
+                if grouped.isDefinedAt(line) then Some(grouped(line)) else None
+              val selectedItem: Seq[Messages.Message] =
+                lineItems
+                  .map { items =>
+                    val filtered = items.filterNot(_.loc.offset == charPosition)
+                    if filtered.nonEmpty then filtered else Seq()
+                  }
+                  .getOrElse(Seq())
+
+              completionList.setItems(
+                selectedItem
+                  .map(msg => {
+                    val item = new CompletionItem()
+                    item.setTextEditText(msg.message)
+                    item
+                  })
+                  .asJava
+              )
+              messages.Either.forRight(
+                completionList
+              )
+            },
+            _ => messages.Either.forLeft(Seq[CompletionItem]().asJava)
+          )
         )
       }
-    )
+    else None
   }
 
   override def didOpen(params: DidOpenTextDocumentParams): Unit = {
@@ -74,25 +162,28 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     riddlDoc = riddlDoc.map(doc =>
       var docLines: Seq[String] = doc.linesIterator.toSeq
       val changes = params.getContentChanges.asScala.toSeq
-      if docLines.nonEmpty then changes.foreach(change => {
-        val changeRangeStart: Position = change.getRange.getStart
-        val changeRangeEnd: Position = change.getRange.getEnd
-        val changesToPatch: Seq[String] = docLines.slice(
-          changeRangeStart.getLine,
-          changeRangeEnd.getLine
-        )
-        val changeLines = change.getText.linesIterator.toSeq
-        val startLinePatch: String = patchLine(docLines.head, change.getRange, changeLines.head)
-        val middlePatch: Seq[String] = changeLines.slice(1, -1)
-        val endLinePatch: String = patchLine(docLines.last, change.getRange, changeLines.last)
+      if docLines.nonEmpty then
+        changes.foreach(change => {
+          val changeRangeStart: Position = change.getRange.getStart
+          val changeRangeEnd: Position = change.getRange.getEnd
+          val changesToPatch: Seq[String] = docLines.slice(
+            changeRangeStart.getLine,
+            changeRangeEnd.getLine
+          )
+          val changeLines = change.getText.getLinesFromText
+          val startLinePatch: String =
+            patchLine(docLines.head, change.getRange, changeLines.head)
+          val middlePatch: Seq[String] = changeLines.slice(1, -1)
+          val endLinePatch: String =
+            patchLine(docLines.last, change.getRange, changeLines.last)
 
-        val finalPatch = startLinePatch +: middlePatch :+ endLinePatch
-        docLines = docLines.patch(
-          changeRangeStart.getLine, //start of replacement
-          startLinePatch +: middlePatch :+ endLinePatch,
-          changeRangeEnd.getLine - changeRangeStart.getLine //length to replace (will be deleted)
-        )
-      })
+          val finalPatch = startLinePatch +: middlePatch :+ endLinePatch
+          docLines = docLines.patch(
+            changeRangeStart.getLine, // start of replacement
+            startLinePatch +: middlePatch :+ endLinePatch,
+            changeRangeEnd.getLine - changeRangeStart.getLine // length to replace (will be deleted)
+          )
+        })
       else docLines = Seq(changes.map(_.getText).mkString("\n"))
       docLines.mkString
     )
@@ -108,4 +199,20 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     updateRIDDLDocFromURI()
     updateParsedDoc()
   }
+
+  // TODO: uncomment and finish when appropriate
+  /*
+  override def references(
+      params: ReferenceParams
+  ): CompletableFuture[util.List[_ <: Location]] = {
+    var foundLocations: Seq[Location] = Seq()
+    riddlDoc.foreach(doc => {
+      val docLines: Seq[String] = doc.linesIterator.toSeq
+
+    })
+    if riddlDoc.isDefined then completableFutureWithSeq(foundLocations)
+    else completableFutureWithSeq(Seq[Location]())
+  }
+   */
+
 }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -3,7 +3,7 @@ package com.ossuminc.riddl.lsp.server
 import com.ossuminc.riddl.language.{AST, Messages}
 import com.ossuminc.riddl.language.Messages.Messages
 import com.ossuminc.riddl.language.parsing.{
-  SourceParserInput,
+  RiddlParserInput,
   StringParserInput,
   TopLevelParser
 }
@@ -12,7 +12,6 @@ import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
 import org.eclipse.lsp4j.{
   CompletionItem,
-  CompletionItemKind,
   CompletionList,
   CompletionParams,
   DidChangeTextDocumentParams,
@@ -37,8 +36,8 @@ def getRootFromUri(uri: String) = {
 }
 
 def parseDocFromSource(docURI: String): Either[Messages, AST.Root] = {
-  val riddlRootDoc = io.Source.fromURL(docURI)
-  new TopLevelParser(SourceParserInput(riddlRootDoc, docURI)).parseRoot()
+  val riddlRootDoc = java.net.URI.create(docURI).toURL
+  new TopLevelParser(RiddlParserInput(riddlRootDoc)).parseRoot()
 }
 
 def parseDocFromString(docString: String): Either[Messages, AST.Root] =
@@ -139,7 +138,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
 
   private def msgToCompletion(msg: Messages.Message): CompletionItem = {
     val item = new CompletionItem()
-    item.setTextEditText(msg.message)
+    item.setDetail(msg.message)
     item
   }
 

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -36,7 +36,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     else parsedDoc = docURI.map(parseDocFromSource)
   }
 
-  private def updateRiddlDocFromURI(): Unit = docURI.foreach(uri => {
+  private def updateRIDDLDocFromURI(): Unit = docURI.foreach(uri => {
     val source = io.Source.fromURL(uri)
     lazy val data: String =
       try {
@@ -102,7 +102,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
   }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = {
-    updateRiddlDocFromURI()
+    updateRIDDLDocFromURI()
     updateParsedDoc()
   }
 }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
@@ -1,0 +1,10 @@
+package com.ossuminc.riddl.lsp.utils
+
+object implicits {
+  implicit class TextProcessing(text: String) {
+    def getLinesFromText: Seq[String] = text
+      .replaceAll("(?<=\\S)(?= {2,})", "\n")
+      .split("\\n")
+      .toSeq
+  }
+}

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/utils/package.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/utils/package.scala
@@ -1,6 +1,17 @@
 package com.ossuminc.riddl.lsp
 
-import org.eclipse.lsp4j.{CompletionOptions, InitializeResult, ServerCapabilities, TextDocumentSyncKind}
+import org.eclipse.lsp4j.{
+  CompletionOptions,
+  InitializeResult,
+  ServerCapabilities,
+  TextDocumentSyncKind
+}
+
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
+import scala.jdk.FutureConverters.*
+import scala.language.implicitConversions
 
 package object utils {
   def createInitializeResultIncremental(): InitializeResult = {
@@ -10,4 +21,12 @@ package object utils {
     result.getCapabilities.setCompletionProvider(new CompletionOptions())
     result
   }
+
+  def completableFutureWithResult[R](result: R): CompletableFuture[R] =
+    Future.successful(result).asJava.toCompletableFuture
+
+  def completableFutureWithSeq[S](
+      result: Seq[S]
+  ): CompletableFuture[java.util.List[_ <: S]] =
+    completableFutureWithResult(result.asJava)
 }

--- a/server/src/test/resources/everything.riddl
+++ b/server/src/test/resources/everything.riddl
@@ -1,0 +1,96 @@
+domain Everything is {
+
+  type SomeType is String
+  command DoAThing is { thingField: Integer }
+
+  context APlant is {
+    source Source is { outlet Commands is DoAThing } described by "Data Source"
+    sink Sink is { inlet Commands is DoAThing } explained as "Data Sink"
+    connector AChannel is {
+      from outlet APlant.Source.Commands to inlet APlant.Sink.Commands
+    } explained as "A Channel"
+  }
+
+  user Author is "human" briefly "An exemplar"
+
+  epic WritingABook is {
+    user Everything.Author wants "to edit on the screen" so that "he can revise content more easily"
+    case primary is { ??? }
+  } described as "A simple authoring story"
+
+  context full is {
+
+    inlet input is type DoAThing
+    connector foo is {
+       from outlet Everything.APlant.Source.Commands to inlet full.input
+    }
+
+    type str is String             // Define str as a String
+    type num is Number             // Define num as a Number
+    type boo is Boolean            // Define boo as a Boolean
+    type ident is Id(Something)    // Define ident as an Id
+    type dat is Date               // Define dat as a Date
+    type tim is Time               // Define tim as a Time
+    type stamp is TimeStamp        // Define stamp as a TimeStamp
+    type url is URL
+
+    type PeachType is { a: Integer }
+    type enum is any of { Apple Pear Peach(23)  Persimmon(24) }
+
+    type alt is one of { enum or stamp or url }
+
+    type agg is {
+      key: num,
+      id: ident,
+      time is TimeStamp
+    }
+
+    type oneOrMore is many agg
+    type zeroOrMore is agg*
+    type optional is agg?
+
+    command ACommand is { ??? }
+
+    entity Something is {
+      option aggregate option transient
+
+      type somethingDate is Date
+
+      event Inebriated is { ??? }
+
+      record fields is { field:  SomeType }
+      state someState of Something.fields is {
+        handler foo is {
+          on command ACommand {
+            "if and(Something arrives, misc()) then"
+              send event Inebriated to inlet Everything.full.input
+            "end"
+          }
+        }
+      }
+
+      function whenUnderTheInfluence is {
+        requires {n: Nothing}
+        returns {b: Boolean}
+        body ???
+      }
+    }
+
+    entity SomeOtherThing is {
+      type ItHappened is event { field: String }
+      record fields is { field: String }
+      state otherThingState of SomeOtherThing.fields is {
+        handler fee is {
+          on event ItHappened {
+             set field SomeOtherThing.otherThingState.field to "field ItHappened.field"
+          }
+        }
+      }
+    }
+    function misc is {
+      requires { n: Nothing }
+      returns { b: Boolean }
+      body ???
+    }
+  }
+}

--- a/server/src/test/resources/everything.riddl
+++ b/server/src/test/resources/everything.riddl
@@ -1,30 +1,34 @@
-domain Everything is {
+// Top Level Author
+author Reid is { name: "Reid" email: "reid@ossum.biz" }
 
-  type SomeType is String
-  command DoAThing is { thingField: Integer }
+// A top level domain
+domain Everything is {
+  // How to mark a definition with the author that created it
+  by author Reid
+
+  type SomeType is String // <-- that's a type
+
+  /* This is another way to do a comment, just like C/C++ */
+  command DoAThing(thingField: Integer)
 
   context APlant is {
-    source Source is { outlet Commands is DoAThing } described by "Data Source"
-    sink Sink is { inlet Commands is DoAThing } explained as "Data Sink"
-    connector AChannel is {
-      from outlet APlant.Source.Commands to inlet APlant.Sink.Commands
-    } explained as "A Channel"
-  }
+    source Source is { outlet Commands is type DoAThing } described by "Data Source"
+    sink Sink is { inlet Commands is type DoAThing } explained as "Data Sink"
 
-  user Author is "human" briefly "An exemplar"
+    connector AChannel is {
+      from outlet Source.Commands
+      to inlet Sink.Commands
+    } explained as "A Channel"
+  } briefly "A bunch of data flow connections"
+
+  user Author is "human" briefly "A scoundrel"
 
   epic WritingABook is {
     user Everything.Author wants "to edit on the screen" so that "he can revise content more easily"
     case primary is { ??? }
-  } described as "A simple authoring story"
+  } described as "A simple authoring epic"
 
   context full is {
-
-    inlet input is type DoAThing
-    connector foo is {
-       from outlet Everything.APlant.Source.Commands to inlet full.input
-    }
-
     type str is String             // Define str as a String
     type num is Number             // Define num as a Number
     type boo is Boolean            // Define boo as a Boolean
@@ -32,12 +36,16 @@ domain Everything is {
     type dat is Date               // Define dat as a Date
     type tim is Time               // Define tim as a Time
     type stamp is TimeStamp        // Define stamp as a TimeStamp
-    type url is URL
+    type url is URL                // Define url as a Uniform Resource Locator
 
-    type PeachType is { a: Integer }
-    type enum is any of { Apple Pear Peach(23)  Persimmon(24) }
+    type PeachType is { a: Integer // can you put a comment here?
+    }
+    type enum is any of { Apple Pear Peach(23)   Persimmon(24) }
 
-    type alt is one of { enum or stamp or url }
+    type alt is one of { enum or stamp or url } described as {
+      | Alternations select one type from a list of types
+    }
+
 
     type agg is {
       key: num,
@@ -49,48 +57,51 @@ domain Everything is {
     type zeroOrMore is agg*
     type optional is agg?
 
-    command ACommand is { ??? }
+    command ACommand()
 
     entity Something is {
-      option aggregate option transient
-
+      option aggregate
+      option transient
+      function misc is {
+        requires { n: Nothing }
+        returns { b: Boolean }
+        body ???
+      }
       type somethingDate is Date
 
       event Inebriated is { ??? }
 
-      record fields is { field:  SomeType }
-      state someState of Something.fields is {
+      record someData(field:  SomeType)
+      state someState of Something.someData is {
         handler foo is {
+          // Handle the ACommand
           on command ACommand {
-            "if and(Something arrives, misc()) then"
-              send event Inebriated to inlet Everything.full.input
-            "end"
+            if "Something arrives" then {
+              // we want to send an event
+              send event Inebriated to outlet APlant.Source.Commands
+            }
           }
         }
       }
 
       function whenUnderTheInfluence is {
-        requires {n: Nothing}
-        returns {b: Boolean}
+        requires { n: Nothing }
+        returns  { b: Boolean }
         body ???
       }
-    }
+    } briefly "Something is nothing interesting"
 
     entity SomeOtherThing is {
       type ItHappened is event { field: String }
-      record fields is { field: String }
-      state otherThingState of SomeOtherThing.fields is {
+      record otherThingData is { field: String }
+      state otherThingState of SomeOtherThing.otherThingData is {
         handler fee is {
           on event ItHappened {
-             set field SomeOtherThing.otherThingState.field to "field ItHappened.field"
+            set field SomeOtherThing.otherThingState.fields.field to
+              "field ItHappened.field"
           }
         }
       }
-    }
-    function misc is {
-      requires { n: Nothing }
-      returns { b: Boolean }
-      body ???
     }
   }
 }

--- a/server/src/test/resources/everythingOneError.riddl
+++ b/server/src/test/resources/everythingOneError.riddl
@@ -1,0 +1,107 @@
+// Top Level Author
+author Reid is { name: "Reid" email: "reid@ossum.biz" }
+
+// A top level domain
+domains Everything is {
+  // How to mark a definition with the author that created it
+  by author Reid
+
+  type SomeType is String // <-- that's a type
+
+  /* This is another way to do a comment, just like C/C++ */
+  command DoAThing(thingField: Integer)
+
+  context APlant is {
+    source Source is { outlet Commands is type DoAThing } described by "Data Source"
+    sink Sink is { inlet Commands is type DoAThing } explained as "Data Sink"
+
+    connector AChannel is {
+      from outlet Source.Commands
+      to inlet Sink.Commands
+    } explained as "A Channel"
+  } briefly "A bunch of data flow connections"
+
+  user Author is "human" briefly "A scoundrel"
+
+  epic WritingABook is {
+    user Everything.Author wants "to edit on the screen" so that "he can revise content more easily"
+    case primary is { ??? }
+  } described as "A simple authoring epic"
+
+  context full is {
+    type str is String             // Define str as a String
+    type num is Number             // Define num as a Number
+    type boo is Boolean            // Define boo as a Boolean
+    type ident is Id(Something)    // Define ident as an Id
+    type dat is Date               // Define dat as a Date
+    type tim is Time               // Define tim as a Time
+    type stamp is TimeStamp        // Define stamp as a TimeStamp
+    type url is URL                // Define url as a Uniform Resource Locator
+
+    type PeachType is { a: Integer // can you put a comment here?
+    }
+    type enum is any of { Apple Pear Peach(23)   Persimmon(24) }
+
+    type alt is one of { enum or stamp or url } described as {
+      | Alternations select one type from a list of types
+    }
+
+
+    type agg is {
+      key: num,
+      id: ident,
+      time is TimeStamp
+    }
+
+    type oneOrMore is many agg
+    type zeroOrMore is agg*
+    type optional is agg?
+
+    command ACommand()
+
+    entity Something is {
+      option aggregate
+      option transient
+      function misc is {
+        requires { n: Nothing }
+        returns { b: Boolean }
+        body ???
+      }
+      type somethingDate is Date
+
+      event Inebriated is { ??? }
+
+      record someData(field:  SomeType)
+      state someState of Something.someData is {
+        handler foo is {
+          // Handle the ACommand
+          on command ACommand {
+            if "Something arrives" then {
+              // we want to send an event
+              send event Inebriated to outlet APlant.Source.Commands
+            }
+          }
+        }
+      }
+
+      function whenUnderTheInfluence is {
+        requires { n: Nothing }
+        returns  { b: Boolean }
+        body ???
+      }
+    } briefly "Something is nothing interesting"
+
+    entity SomeOtherThing is {
+      type ItHappened is event { field: String }
+      record otherThingData is { field: String }
+      state otherThingState of SomeOtherThing.otherThingData is {
+        handler fee is {
+          on event ItHappened {
+            set field SomeOtherThing.otherThingState.fields.field to
+              "field ItHappened.field"
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -165,11 +165,12 @@ class RiddlLSPTextDocumentSpec
       whenReady(resultF.asScala) { eitherList =>
         eitherList.isRight mustBe true
         eitherList.getRight.getItems.asScala.length mustEqual 1
-        eitherList.getRight.getItems.asScala.head.getTextEditText mustEqual
+        eitherList.getRight.getItems.asScala.head.getDetail mustEqual
           """Expected one of (end-of-input | whitespace after keyword)"""
       }
     }
 
+    /* TODO: Finish these tests immediately
     "successfully close everythingOneError.riddl" in new OpenOneErrorFileSpec {
       val closeNotification: DidCloseTextDocumentParams =
         new DidCloseTextDocumentParams()
@@ -192,6 +193,7 @@ class RiddlLSPTextDocumentSpec
       saveNotification.setTextDocument(textDocumentIdentifier)
       service.didSave(saveNotification)
     }
+     */
   }
 
 }

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -1,0 +1,142 @@
+package com.ossum.riddl.lsp.server
+
+import com.ossuminc.riddl.lsp.server.{RiddlLSPServer, RiddlLSPTextDocumentService, RiddlLSPWorkspaceService}
+import com.ossuminc.riddl.lsp.utils.createInitializeResultIncremental
+import org.eclipse.lsp4j
+import org.eclipse.lsp4j.{DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, InitializeParams, InitializeResult, Position, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, VersionedTextDocumentIdentifier}
+import org.mockito.Mockito.mock
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Path
+import scala.io.{BufferedSource, Source}
+import scala.language.postfixOps
+import scala.jdk.CollectionConverters.*
+
+class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
+  val filePath = "server/src/test/resources/everything.riddl"
+  val file: BufferedSource = Source.fromFile(filePath)
+  val doc: String = file.getLines().mkString
+  file.close()
+  val docURI: String = Path.of(filePath).toUri.toString
+
+  trait EverythingInitializeSpec {
+    val textDocumentItem: TextDocumentItem = new TextDocumentItem()
+    textDocumentItem.setText(doc)
+    textDocumentItem.setUri(docURI)
+    val textDocumentIdentifier: TextDocumentIdentifier = new TextDocumentIdentifier()
+    textDocumentIdentifier.setUri(docURI)
+
+    val service: RiddlLSPTextDocumentService = RiddlLSPTextDocumentService()
+  }
+
+  trait EmptyInitializeSpec {
+    val emptyDocURI: String = Path.of("server/src/test/resources/empty.riddl").toUri.toString
+    val textDocumentItem: TextDocumentItem = new TextDocumentItem()
+    textDocumentItem.setText("")
+    textDocumentItem.setUri(emptyDocURI)
+    val textDocumentIdentifier: TextDocumentIdentifier = new TextDocumentIdentifier()
+    textDocumentIdentifier.setUri(emptyDocURI)
+
+    val service: RiddlLSPTextDocumentService = RiddlLSPTextDocumentService()
+  }
+
+  trait OpenEverythingFileSpec extends EverythingInitializeSpec {
+    val openNotification: DidOpenTextDocumentParams = new DidOpenTextDocumentParams()
+    openNotification.setTextDocument(
+      textDocumentItem
+    )
+
+    service.didOpen(openNotification)
+  }
+
+  trait OpenEmptyFileSpec extends EmptyInitializeSpec {
+    val openNotification: DidOpenTextDocumentParams = new DidOpenTextDocumentParams()
+    openNotification.setTextDocument(
+      textDocumentItem
+    )
+
+    service.didOpen(openNotification)
+  }
+
+  trait ChangeEverythingFileSpec extends OpenEverythingFileSpec {
+    val changeNotification: DidChangeTextDocumentParams = new DidChangeTextDocumentParams()
+
+    val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
+    versionedDocIdentifier.setUri(docURI)
+    changeNotification.setTextDocument(versionedDocIdentifier)
+
+    val changes = new TextDocumentContentChangeEvent()
+    changes.setText("the")
+    val changeRange = new lsp4j.Range()
+
+    val changeStart = new Position()
+    changeStart.setLine(11)
+    changeStart.setCharacter(21)
+    changeRange.setStart(changeStart)
+
+    val changeEnd = new Position()
+    changeEnd.setLine(11)
+    changeEnd.setCharacter(24)
+    changeRange.setEnd(changeEnd)
+
+    changes.setRange(changeRange)
+    changeNotification.setContentChanges(List(changes).asJava)
+
+    service.didChange(changeNotification)
+  }
+
+  trait ChangeEmptyFileSpec extends OpenEmptyFileSpec {
+    val changeNotification: DidChangeTextDocumentParams = new DidChangeTextDocumentParams()
+
+    val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
+    versionedDocIdentifier.setUri(docURI)
+    changeNotification.setTextDocument(versionedDocIdentifier)
+
+    val changes = new TextDocumentContentChangeEvent()
+    changes.setText("domain New {}")
+    val changeRange = new lsp4j.Range()
+
+    val changeStart = new Position()
+    changeStart.setLine(1)
+    changeStart.setCharacter(1)
+    changeRange.setStart(changeStart)
+
+    val changeEnd = new Position()
+    changeEnd.setLine(1)
+    changeEnd.setCharacter(1)
+    changeRange.setEnd(changeEnd)
+
+    changes.setRange(changeRange)
+    changeNotification.setContentChanges(List(changes).asJava)
+
+    service.didChange(changeNotification)
+  }
+
+  "RiddlLSPTextDocumentService" must {
+    "successfully open everything.riddl" in new OpenEverythingFileSpec {}
+
+    "successfully close everything.riddl" in new OpenEverythingFileSpec {
+      val closeNotification: DidCloseTextDocumentParams = new DidCloseTextDocumentParams()
+      closeNotification.setTextDocument(textDocumentIdentifier)
+      service.didClose(closeNotification)
+    }
+
+    "successfully change everything.riddl" in new ChangeEverythingFileSpec { }
+
+    "successfully save everything.riddl" in new ChangeEverythingFileSpec {
+      val saveNotification = new DidSaveTextDocumentParams()
+      saveNotification.setTextDocument(textDocumentIdentifier)
+      service.didSave(saveNotification)
+    }
+
+    "successfully change empty.riddl" in new ChangeEmptyFileSpec {}
+
+    "successfully save empty.riddl" in new ChangeEmptyFileSpec {
+      val saveNotification = new DidSaveTextDocumentParams()
+      saveNotification.setTextDocument(textDocumentIdentifier)
+      service.didSave(saveNotification)
+    }
+  }
+
+}

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -1,48 +1,72 @@
 package com.ossum.riddl.lsp.server
 
-import com.ossuminc.riddl.lsp.server.{RiddlLSPServer, RiddlLSPTextDocumentService, RiddlLSPWorkspaceService}
-import com.ossuminc.riddl.lsp.utils.createInitializeResultIncremental
+import com.ossuminc.riddl.lsp.server.RiddlLSPTextDocumentService
 import org.eclipse.lsp4j
-import org.eclipse.lsp4j.{DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, InitializeParams, InitializeResult, Position, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, VersionedTextDocumentIdentifier}
-import org.mockito.Mockito.mock
+import org.eclipse.lsp4j.jsonrpc.messages
+import org.eclipse.lsp4j.{
+  CompletionItem,
+  CompletionList,
+  CompletionParams,
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+  Position,
+  TextDocumentContentChangeEvent,
+  TextDocumentIdentifier,
+  TextDocumentItem,
+  VersionedTextDocumentIdentifier
+}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Path
+import java.util
 import scala.io.{BufferedSource, Source}
 import scala.language.postfixOps
 import scala.jdk.CollectionConverters.*
+import scala.jdk.FutureConverters.*
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
-  val filePath = "server/src/test/resources/everything.riddl"
-  val file: BufferedSource = Source.fromFile(filePath)
-  val doc: String = file.getLines().mkString
-  file.close()
-  val docURI: String = Path.of(filePath).toUri.toString
+  trait EverythingFileSpec {
+    val filePath = "server/src/test/resources/everything.riddl"
+    val file: BufferedSource = Source.fromFile(filePath)
+    val doc: String = file.getLines().mkString
+    file.close()
+    val docURI: String = Path.of(filePath).toUri.toString
+  }
 
-  trait EverythingInitializeSpec {
+  trait EverythingInitializeSpec extends EverythingFileSpec {
+
     val textDocumentItem: TextDocumentItem = new TextDocumentItem()
     textDocumentItem.setText(doc)
     textDocumentItem.setUri(docURI)
-    val textDocumentIdentifier: TextDocumentIdentifier = new TextDocumentIdentifier()
+    val textDocumentIdentifier: TextDocumentIdentifier =
+      new TextDocumentIdentifier()
     textDocumentIdentifier.setUri(docURI)
 
     val service: RiddlLSPTextDocumentService = RiddlLSPTextDocumentService()
   }
 
   trait EmptyInitializeSpec {
-    val emptyDocURI: String = Path.of("server/src/test/resources/empty.riddl").toUri.toString
+    val emptyDocURI: String =
+      Path.of("server/src/test/resources/empty.riddl").toUri.toString
+
     val textDocumentItem: TextDocumentItem = new TextDocumentItem()
     textDocumentItem.setText("")
     textDocumentItem.setUri(emptyDocURI)
-    val textDocumentIdentifier: TextDocumentIdentifier = new TextDocumentIdentifier()
+    val textDocumentIdentifier: TextDocumentIdentifier =
+      new TextDocumentIdentifier()
     textDocumentIdentifier.setUri(emptyDocURI)
 
     val service: RiddlLSPTextDocumentService = RiddlLSPTextDocumentService()
   }
 
   trait OpenEverythingFileSpec extends EverythingInitializeSpec {
-    val openNotification: DidOpenTextDocumentParams = new DidOpenTextDocumentParams()
+    val openNotification: DidOpenTextDocumentParams =
+      new DidOpenTextDocumentParams()
     openNotification.setTextDocument(
       textDocumentItem
     )
@@ -51,7 +75,8 @@ class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
   }
 
   trait OpenEmptyFileSpec extends EmptyInitializeSpec {
-    val openNotification: DidOpenTextDocumentParams = new DidOpenTextDocumentParams()
+    val openNotification: DidOpenTextDocumentParams =
+      new DidOpenTextDocumentParams()
     openNotification.setTextDocument(
       textDocumentItem
     )
@@ -60,7 +85,8 @@ class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
   }
 
   trait ChangeEverythingFileSpec extends OpenEverythingFileSpec {
-    val changeNotification: DidChangeTextDocumentParams = new DidChangeTextDocumentParams()
+    val changeNotification: DidChangeTextDocumentParams =
+      new DidChangeTextDocumentParams()
 
     val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
     versionedDocIdentifier.setUri(docURI)
@@ -86,8 +112,9 @@ class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
     service.didChange(changeNotification)
   }
 
-  trait ChangeEmptyFileSpec extends OpenEmptyFileSpec {
-    val changeNotification: DidChangeTextDocumentParams = new DidChangeTextDocumentParams()
+  trait ChangeEmptyFileSpec extends OpenEmptyFileSpec with EverythingFileSpec {
+    val changeNotification: DidChangeTextDocumentParams =
+      new DidChangeTextDocumentParams()
 
     val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
     versionedDocIdentifier.setUri(docURI)
@@ -114,15 +141,34 @@ class RiddlLSPTextDocumentSpec extends AnyWordSpec with Matchers {
   }
 
   "RiddlLSPTextDocumentService" must {
-    "successfully open everything.riddl" in new OpenEverythingFileSpec {}
+    "successfully open everything.riddl & get completion" in new OpenEverythingFileSpec {
+      val params = new CompletionParams()
+      params.setTextDocument(textDocumentIdentifier)
+      val position = new Position()
+      position.setLine(1)
+      position.setCharacter(0)
+      params.setPosition(position)
+      val resultF
+          : Future[messages.Either[util.List[CompletionItem], CompletionList]] =
+        service.completion(params).asScala
+      resultF.map { eitherList =>
+        eitherList.isRight mustBe true
+        eitherList.getRight.getItems
+          .get(
+            0
+          )
+          .getTextEditText mustEqual """"Expected one of ("/*" | "//" | "adaptor" | "by" | "command" | "connector" | "entity" | "event" | "flow" | "function" | "graph" | "handler" | "include" | "inlet" | "merge" | "option" | "outlet" | "projector" | "query" | "record" | "repository" | "result" | "router" | "saga" | "sink" | "source" | "split" | "table" | "term" | "type" | "void" | "}")""""
+      }
+    }
 
     "successfully close everything.riddl" in new OpenEverythingFileSpec {
-      val closeNotification: DidCloseTextDocumentParams = new DidCloseTextDocumentParams()
+      val closeNotification: DidCloseTextDocumentParams =
+        new DidCloseTextDocumentParams()
       closeNotification.setTextDocument(textDocumentIdentifier)
       service.didClose(closeNotification)
     }
 
-    "successfully change everything.riddl" in new ChangeEverythingFileSpec { }
+    "successfully change everything.riddl" in new ChangeEverythingFileSpec {}
 
     "successfully save everything.riddl" in new ChangeEverythingFileSpec {
       val saveNotification = new DidSaveTextDocumentParams()


### PR DESCRIPTION
didOpen, didClose, didSave, didChange are now filled out

Initial testing has been done, ensuring that all lines are being hit on correct paths by inserting divide by zero errors in local testing. I suggest using breakpoints if one wants to test that flows proceed through all necessary steps in a local environment.

A more robust testing solution entails finding a function which returns data regarding the document that is in memory, and then checking to make sure that that data is accurate. This is the next step, as the document's integrity in the server should be sound & stable before moving on to [parsing the docString to RIDDL AST](https://github.com/ossuminc/riddl-lsp/issues/74), which will require finding a separate function for returning AST-based data that can be checked in tests.