### PR TITLE
diagnostic + cleanup [LSP-46]

### DIFF
--- a/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
@@ -1,10 +1,33 @@
 package com.ossuminc.riddl.lsp.utils
 
+import com.ossuminc.riddl.language.Messages
+import org.eclipse.lsp4j.{Location, Position, Range}
+
 object implicits {
   implicit class TextProcessing(text: String) {
     def getLinesFromText: Seq[String] = text
       .replaceAll("(?<=\\S)(?= {2,})", "\n")
       .split("\\n")
       .toSeq
+  }
+
+  implicit class RIDDLMsg2LSP4JLoc(msg: Messages.Message) {
+    def toLSP4JLocation: Location = {
+      val location = new Location()
+      val range = new Range()
+
+      val startPosition = new Position()
+      startPosition.setLine(msg.loc.line)
+      startPosition.setCharacter(msg.loc.offset)
+      val endPosition = new Position()
+      endPosition.setLine(msg.loc.line)
+      endPosition.setCharacter(msg.loc.offset + msg.context.length)
+
+      range.setStart(startPosition)
+      range.setEnd(endPosition)
+      location.setRange(range)
+
+      location
+    }
   }
 }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/utils/implicits.scala
@@ -6,27 +6,30 @@ import org.eclipse.lsp4j.{Location, Position, Range}
 object implicits {
   implicit class TextProcessing(text: String) {
     def getLinesFromText: Seq[String] = text
-      .replaceAll("(?<=\\S)(?= {2,})", "\n")
+      // .replaceAll("(?<=\\S)(?= {2,})", "\n")
       .split("\\n")
       .toSeq
   }
 
-  implicit class RIDDLMsg2LSP4JLoc(msg: Messages.Message) {
-    def toLSP4JLocation: Location = {
-      val location = new Location()
+  implicit class RIDDLMsg2LSP4J(msg: Messages.Message) {
+    def toLSP4JRange: Range = {
       val range = new Range()
 
       val startPosition = new Position()
       startPosition.setLine(msg.loc.line)
-      startPosition.setCharacter(msg.loc.offset)
+      startPosition.setCharacter(msg.loc.col)
       val endPosition = new Position()
       endPosition.setLine(msg.loc.line)
-      endPosition.setCharacter(msg.loc.offset + msg.context.length)
+      endPosition.setCharacter(msg.loc.col + msg.context.length)
 
       range.setStart(startPosition)
       range.setEnd(endPosition)
-      location.setRange(range)
+      range
+    }
 
+    def toLSP4JLocation: Location = {
+      val location = new Location()
+      location.setRange(msg.toLSP4JRange)
       location
     }
   }

--- a/server/src/main/scala/com/ossuminc/riddl/lsp/utils/package.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/utils/package.scala
@@ -14,6 +14,15 @@ import scala.jdk.FutureConverters.*
 import scala.language.implicitConversions
 
 package object utils {
+  def parseFromURI(uri: String): String = {
+    val source = io.Source.fromURL(uri)
+    try {
+      source.getLines().mkString("\n")
+    } finally {
+      source.close()
+    }
+  }
+
   def createInitializeResultIncremental(): InitializeResult = {
     val result = new InitializeResult(new ServerCapabilities())
 

--- a/server/src/test/resources/everything.riddl
+++ b/server/src/test/resources/everything.riddl
@@ -9,7 +9,7 @@ domain Everything is {
   type SomeType is String // <-- that's a type
 
   /* This is another way to do a comment, just like C/C++ */
-  command DoAThing(thingField: Integer)
+  command DoAThing is { thingField: Integer }
 
   context APlant is {
     source Source is { outlet Commands is type DoAThing } described by "Data Source"
@@ -57,7 +57,7 @@ domain Everything is {
     type zeroOrMore is agg*
     type optional is agg?
 
-    command ACommand()
+    command ACommand is { ??? }
 
     entity Something is {
       option aggregate
@@ -71,7 +71,7 @@ domain Everything is {
 
       event Inebriated is { ??? }
 
-      record someData(field:  SomeType)
+      record someData is { field: SomeType }
       state someState of Something.someData is {
         handler foo is {
           // Handle the ACommand
@@ -97,7 +97,7 @@ domain Everything is {
       state otherThingState of SomeOtherThing.otherThingData is {
         handler fee is {
           on event ItHappened {
-            set field SomeOtherThing.otherThingState.fields.field to
+            set field SomeOtherThing.otherThingState.field to
               "field ItHappened.field"
           }
         }

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
@@ -1,0 +1,171 @@
+package com.ossum.riddl.lsp
+
+import com.ossuminc.riddl.lsp.server.RiddlLSPTextDocumentService
+import org.eclipse.lsp4j.{
+  DidChangeTextDocumentParams,
+  DidOpenTextDocumentParams,
+  Position,
+  TextDocumentContentChangeEvent,
+  TextDocumentIdentifier,
+  TextDocumentItem,
+  VersionedTextDocumentIdentifier
+}
+
+import java.nio.file.Path
+import scala.collection.immutable.List
+import scala.io.{BufferedSource, Source}
+
+import org.eclipse.lsp4j
+import scala.jdk.CollectionConverters.*
+
+package server {
+
+  import com.ossuminc.riddl.lsp.utils.parseFromURI
+
+  object InitializationSpecs {
+    trait DocumentIdentifierSpec {
+      val textDocumentIdentifier: TextDocumentIdentifier =
+        new TextDocumentIdentifier()
+
+      val service: RiddlLSPTextDocumentService =
+        new RiddlLSPTextDocumentService()
+    }
+
+    trait NonEmptyFileSpec {
+      val filePath: String
+    }
+
+    trait NoErrorFileSpec extends NonEmptyFileSpec {
+      override val filePath =
+        "server/src/test/resources/everything.riddl"
+    }
+
+    trait OneErrorFileSpec extends NonEmptyFileSpec {
+      override val filePath =
+        "server/src/test/resources/everythingOneError.riddl"
+
+      val errorLine = 5
+      val errorCharOnLine = 7
+    }
+
+    trait NoErrorInitializeSpec
+        extends NoErrorFileSpec
+        with DocumentIdentifierSpec {
+      val noErrorDocURI: String = Path.of(filePath).toUri.toString
+      val noErrorDoc: String = parseFromURI(noErrorDocURI)
+
+      val textDocumentItem: TextDocumentItem = new TextDocumentItem()
+      textDocumentItem.setText(noErrorDoc)
+      textDocumentItem.setUri(noErrorDocURI)
+      textDocumentIdentifier.setUri(noErrorDocURI)
+    }
+
+    trait OneErrorInitializeSpec
+        extends OneErrorFileSpec
+        with DocumentIdentifierSpec {
+      val oneErrorDocURI: String = Path.of(filePath).toUri.toString
+      val oneErrorDoc: String = parseFromURI(oneErrorDocURI)
+
+      val textDocumentItem: TextDocumentItem = new TextDocumentItem()
+      textDocumentItem.setText(oneErrorDoc)
+      textDocumentItem.setUri(oneErrorDocURI)
+      textDocumentIdentifier.setUri(oneErrorDocURI)
+    }
+
+    trait EmptyInitializeSpec extends DocumentIdentifierSpec {
+      val emptyDocURI: String =
+        Path.of("server/src/test/resources/empty.riddl").toUri.toString
+
+      val textDocumentItem: TextDocumentItem = new TextDocumentItem()
+      textDocumentItem.setText("")
+      textDocumentItem.setUri(emptyDocURI)
+      textDocumentIdentifier.setUri(emptyDocURI)
+    }
+
+    trait OpenNoErrorFileSpec extends NoErrorInitializeSpec {
+      val openNotification: DidOpenTextDocumentParams =
+        new DidOpenTextDocumentParams()
+      openNotification.setTextDocument(
+        textDocumentItem
+      )
+
+      service.didOpen(openNotification)
+    }
+
+    trait OpenOneErrorFileSpec extends OneErrorInitializeSpec {
+      val openNotification: DidOpenTextDocumentParams =
+        new DidOpenTextDocumentParams()
+      openNotification.setTextDocument(
+        textDocumentItem
+      )
+
+      service.didOpen(openNotification)
+    }
+
+    trait OpenEmptyFileSpec extends EmptyInitializeSpec {
+      val openNotification: DidOpenTextDocumentParams =
+        new DidOpenTextDocumentParams()
+      openNotification.setTextDocument(
+        textDocumentItem
+      )
+
+      service.didOpen(openNotification)
+    }
+
+    trait ChangeOneErrorFileSpec extends OpenOneErrorFileSpec {
+      val changeNotification: DidChangeTextDocumentParams =
+        new DidChangeTextDocumentParams()
+
+      val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
+      versionedDocIdentifier.setUri(oneErrorDocURI)
+      changeNotification.setTextDocument(versionedDocIdentifier)
+
+      val changes = new TextDocumentContentChangeEvent()
+      changes.setText("the")
+      val changeRange = new lsp4j.Range()
+
+      val changeStart = new Position()
+      changeStart.setLine(11)
+      changeStart.setCharacter(21)
+      changeRange.setStart(changeStart)
+
+      val changeEnd = new Position()
+      changeEnd.setLine(11)
+      changeEnd.setCharacter(24)
+      changeRange.setEnd(changeEnd)
+
+      changes.setRange(changeRange)
+      changeNotification.setContentChanges(List(changes).asJava)
+
+      service.didChange(changeNotification)
+    }
+
+    trait ChangeEmptyFileSpec extends OpenEmptyFileSpec with NonEmptyFileSpec {
+      val changeNotification: DidChangeTextDocumentParams =
+        new DidChangeTextDocumentParams()
+
+      val versionedDocIdentifier = new VersionedTextDocumentIdentifier()
+      versionedDocIdentifier.setUri(emptyDocURI)
+      changeNotification.setTextDocument(versionedDocIdentifier)
+
+      val changes = new TextDocumentContentChangeEvent()
+      changes.setText("domain New {}")
+      val changeRange = new lsp4j.Range()
+
+      val changeStart = new Position()
+      changeStart.setLine(1)
+      changeStart.setCharacter(1)
+      changeRange.setStart(changeStart)
+
+      val changeEnd = new Position()
+      changeEnd.setLine(1)
+      changeEnd.setCharacter(1)
+      changeRange.setEnd(changeEnd)
+
+      changes.setRange(changeRange)
+      changeNotification.setContentChanges(List(changes).asJava)
+
+      service.didChange(changeNotification)
+    }
+  }
+}


### PR DESCRIPTION
- implements the diagnostic function
  - was going to use for testing instead of `completion` but realized too late it operates on a `URI` in the request params instead of the open doc
- extra error cases with tests for them
  - maintains previous tests merged in (`didOpen`, `didClose`)