### PR TITLE
didSave [LSP_46]

### DIFF
--- a/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
+++ b/server/src/main/scala/com/ossuminc/riddl/lsp/server/RiddlLSPTextDocumentService.scala
@@ -7,23 +7,7 @@ import com.ossuminc.riddl.lsp.utils.implicits.*
 import com.ossuminc.riddl.lsp.utils.parseFromURI
 import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{
-  CompletionItem,
-  CompletionList,
-  CompletionParams,
-  Diagnostic,
-  DiagnosticRelatedInformation,
-  DiagnosticSeverity,
-  DidChangeTextDocumentParams,
-  DidCloseTextDocumentParams,
-  DidOpenTextDocumentParams,
-  DidSaveTextDocumentParams,
-  DocumentDiagnosticParams,
-  DocumentDiagnosticReport,
-  Location,
-  Position,
-  RelatedFullDocumentDiagnosticReport
-}
+import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.services.TextDocumentService
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -72,7 +56,9 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     updateDocLines()
   }
 
-  private def updateRIDDLDocFromURI(): Unit = docURI.foreach { uri =>
+  private def updateRIDDLDocFromURI(
+      uri: String = docURI.getOrElse("")
+  ): Unit = {
     val data = parseFromURI(uri)
     riddlDoc = if data.nonEmpty then Some(data) else None
   }
@@ -149,7 +135,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
     val selectedItem: Seq[Messages.Message] =
       lineItems
         .map { items =>
-          val filtered = items.filterNot(_.loc.offset == charPosition)
+          val filtered = items.filter(_.loc.col == charPosition)
           if filtered.nonEmpty then filtered else Seq()
         }
         .getOrElse(Seq())
@@ -225,7 +211,7 @@ class RiddlLSPTextDocumentService extends TextDocumentService {
   }
 
   override def didSave(params: DidSaveTextDocumentParams): Unit = {
-    updateRIDDLDocFromURI()
+    updateRIDDLDocFromURI(params.getTextDocument.getUri)
     updateParsedDoc()
   }
 

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
@@ -1,15 +1,7 @@
 package com.ossum.riddl.lsp
 
 import com.ossuminc.riddl.lsp.server.RiddlLSPTextDocumentService
-import org.eclipse.lsp4j.{
-  DidChangeTextDocumentParams,
-  DidOpenTextDocumentParams,
-  Position,
-  TextDocumentContentChangeEvent,
-  TextDocumentIdentifier,
-  TextDocumentItem,
-  VersionedTextDocumentIdentifier
-}
+import org.eclipse.lsp4j.*
 
 import java.nio.file.Path
 import scala.collection.immutable.List
@@ -73,13 +65,15 @@ package server {
     }
 
     trait EmptyInitializeSpec extends DocumentIdentifierSpec {
-      val emptyDocURI: String =
-        Path.of("server/src/test/resources/empty.riddl").toUri.toString
+      val emptyDocURI = "server/src/test/resources/empty.riddl"
+
+      val emptyDocURIFromPath: String =
+        Path.of(emptyDocURI).toUri.toString
 
       val textDocumentItem: TextDocumentItem = new TextDocumentItem()
       textDocumentItem.setText("")
-      textDocumentItem.setUri(emptyDocURI)
-      textDocumentIdentifier.setUri(emptyDocURI)
+      textDocumentItem.setUri(emptyDocURIFromPath)
+      textDocumentIdentifier.setUri(emptyDocURIFromPath)
     }
 
     trait OpenNoErrorFileSpec extends NoErrorInitializeSpec {
@@ -140,7 +134,9 @@ package server {
       service.didChange(changeNotification)
     }
 
-    trait ChangeEmptyFileSpec extends OpenEmptyFileSpec with NonEmptyFileSpec {
+    trait ChangeEmptyFileSpec extends OpenEmptyFileSpec {
+      val textChange = "domain New {}"
+
       val changeNotification: DidChangeTextDocumentParams =
         new DidChangeTextDocumentParams()
 
@@ -149,7 +145,7 @@ package server {
       changeNotification.setTextDocument(versionedDocIdentifier)
 
       val changes = new TextDocumentContentChangeEvent()
-      changes.setText("domain New {}")
+      changes.setText(textChange)
       val changeRange = new lsp4j.Range()
 
       val changeStart = new Position()

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -3,21 +3,13 @@ package com.ossum.riddl.lsp.server
 import com.ossum.riddl.lsp.server.InitializationSpecs.*
 import org.eclipse.lsp4j
 import org.eclipse.lsp4j.jsonrpc.messages
-import org.eclipse.lsp4j.{
-  CompletionItem,
-  CompletionList,
-  CompletionParams,
-  DidCloseTextDocumentParams,
-  DocumentDiagnosticParams,
-  DocumentDiagnosticReport,
-  DocumentDiagnosticReportKind,
-  Position
-}
-import org.scalatest.concurrent.Futures.whenReady
+import org.eclipse.lsp4j.*
+import org.scalatest.concurrent.Futures.{whenReady, whenReadyImpl}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.io.File
 import java.util
 import java.util.concurrent.CompletableFuture
 import scala.concurrent.Future
@@ -42,7 +34,8 @@ class RiddlLSPTextDocumentSpec
     var completionResultF: CompletableFuture[
       messages.Either[util.List[CompletionItem], CompletionList]
     ] = Future.failed(new Throwable()).asJava.toCompletableFuture
-    def makeRequest(): Unit = {
+
+    def requestCompletion(): Unit = {
       params.setPosition(position)
 
       completionResultF = service.completion(params)
@@ -60,7 +53,7 @@ class RiddlLSPTextDocumentSpec
       with DiagnosticRequestSpec {
       position.setLine(1)
       position.setCharacter(1)
-      makeRequest()
+      requestCompletion()
 
       completionResultF.asScala.failed.futureValue mustBe a[Throwable]
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document has no errors"
@@ -71,7 +64,7 @@ class RiddlLSPTextDocumentSpec
 
       position.setLine(errorLine)
       position.setCharacter(errorCharOnLine)
-      makeRequest()
+      requestCompletion()
 
       whenReady(completionResultF.asScala) { completion =>
         completion.isRight mustBe true
@@ -85,7 +78,7 @@ class RiddlLSPTextDocumentSpec
 
       position.setLine(1)
       position.setCharacter(1)
-      makeRequest()
+      requestCompletion()
 
       completionResultF.asScala.failed.futureValue mustBe a[Throwable]
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document is empty"
@@ -100,7 +93,7 @@ class RiddlLSPTextDocumentSpec
 
       position.setLine(1)
       position.setCharacter(1)
-      makeRequest()
+      requestCompletion()
 
       completionResultF.asScala.failed.futureValue mustBe a[Throwable]
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document is closed"
@@ -110,7 +103,7 @@ class RiddlLSPTextDocumentSpec
       with CompletionRequestSpec {
       position.setLine(1)
       position.setCharacter(1)
-      makeRequest()
+      requestCompletion()
 
       completionResultF.asScala.failed.futureValue mustBe a[Throwable]
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document has no errors"
@@ -120,12 +113,12 @@ class RiddlLSPTextDocumentSpec
       with CompletionRequestSpec {
       position.setLine(errorLine)
       position.setCharacter(errorCharOnLine)
-      makeRequest()
+      requestCompletion()
 
-      whenReady(completionResultF.asScala) { eitherList =>
-        eitherList.isRight mustBe true
-        eitherList.getRight.getItems.asScala.length mustEqual 1
-        eitherList.getRight.getItems.asScala.head.getDetail mustEqual
+      whenReady(completionResultF.asScala) { completionList =>
+        completionList.isRight mustBe true
+        completionList.getRight.getItems.asScala.length mustEqual 1
+        completionList.getRight.getItems.asScala.head.getDetail mustEqual
           """Expected one of (end-of-input | whitespace after keyword)"""
       }
     }
@@ -160,12 +153,42 @@ class RiddlLSPTextDocumentSpec
 
     "successfully change empty.riddl" in new ChangeEmptyFileSpec {}
 
-    "successfully save empty.riddl" in new ChangeEmptyFileSpec {
+     */
+
+    "successfully save empty.riddl" in new ChangeEmptyFileSpec
+      with CompletionRequestSpec
+      with DiagnosticRequestSpec {
+
+      // ensuring state before the test
+      position.setLine(1)
+      position.setCharacter(1)
+      requestCompletion()
+      completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document is empty"
+
+      // Need to actually change the file before running the test
+      var p = new java.io.PrintWriter(new File(emptyDocURI))
+      try { p.println(textChange) }
+      finally { p.close() }
+
       val saveNotification = new DidSaveTextDocumentParams()
       saveNotification.setTextDocument(textDocumentIdentifier)
       service.didSave(saveNotification)
+
+      position.setLine(1)
+      position.setCharacter(13)
+      requestCompletion()
+
+      whenReady(completionResultF.asScala) { completion =>
+        completion.isRight mustEqual true
+        completion.getRight.getItems.asScala.length mustEqual 1
+        completion.getRight.getItems.asScala.head.getDetail mustEqual
+          """Expected one of ("/*" | "//" | "???" | "application" | "author" | "by" | "command" | "constant" | "context" | "domain" | "epic" | "event" | "graph" | "import" | "include" | "option" | "query" | "record" | "result" | "saga" | "table" | "term" | "type" | "user")"""
+      }
+
+      p = new java.io.PrintWriter(new File(emptyDocURI))
+      try { p.print("") }
+      finally { p.close() }
     }
-     */
   }
 
 }


### PR DESCRIPTION
Allows for testing & tests `didSave` using a URL (no use of `text` string in params for `didSave`)

Also includes a small change to a filter statement that was resulting in all completions being returned for the whole document instead of the specific one requested (needs a file with more than one error for testing)