### PR TITLE
didChange tested [LSP_9]

### DIFF
--- a/server/src/test/resources/everythingOneError.riddl
+++ b/server/src/test/resources/everythingOneError.riddl
@@ -9,7 +9,7 @@ domains Everything is {
   type SomeType is String // <-- that's a type
 
   /* This is another way to do a comment, just like C/C++ */
-  command DoAThing(thingField: Integer)
+  command DoAThing is { thingField: Integer }
 
   context APlant is {
     source Source is { outlet Commands is type DoAThing } described by "Data Source"
@@ -57,7 +57,7 @@ domains Everything is {
     type zeroOrMore is agg*
     type optional is agg?
 
-    command ACommand()
+    command ACommand is { ??? }
 
     entity Something is {
       option aggregate
@@ -71,7 +71,7 @@ domains Everything is {
 
       event Inebriated is { ??? }
 
-      record someData(field:  SomeType)
+      record someData is { field:  SomeType }
       state someState of Something.someData is {
         handler foo is {
           // Handle the ACommand

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/InitializationSpecs.scala
@@ -107,6 +107,8 @@ package server {
     }
 
     trait ChangeOneErrorFileSpec extends OpenOneErrorFileSpec {
+      val textChange = "domain"
+
       val changeNotification: DidChangeTextDocumentParams =
         new DidChangeTextDocumentParams()
 
@@ -115,17 +117,17 @@ package server {
       changeNotification.setTextDocument(versionedDocIdentifier)
 
       val changes = new TextDocumentContentChangeEvent()
-      changes.setText("the")
+      changes.setText(textChange)
       val changeRange = new lsp4j.Range()
 
       val changeStart = new Position()
-      changeStart.setLine(11)
-      changeStart.setCharacter(21)
+      changeStart.setLine(5)
+      changeStart.setCharacter(1)
       changeRange.setStart(changeStart)
 
       val changeEnd = new Position()
-      changeEnd.setLine(11)
-      changeEnd.setCharacter(24)
+      changeEnd.setLine(5)
+      changeEnd.setCharacter(8)
       changeRange.setEnd(changeEnd)
 
       changes.setRange(changeRange)
@@ -135,7 +137,13 @@ package server {
     }
 
     trait ChangeEmptyFileSpec extends OpenEmptyFileSpec {
-      val textChange = "domain New {}"
+      val errorLine = 2
+      val errorLineChar = 7
+
+      val textChange: String =
+        """domain New {
+          |  typesss
+          |}""".stripMargin
 
       val changeNotification: DidChangeTextDocumentParams =
         new DidChangeTextDocumentParams()

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -153,7 +153,7 @@ class RiddlLSPTextDocumentSpec
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document has no errors"
     }
 
-    "successfully change empty.riddl, expecting 2 errors" in new ChangeEmptyFileSpec
+    "successfully change empty.riddl, expecting an error" in new ChangeEmptyFileSpec
       with CompletionRequestSpec {
       position.setLine(errorLine)
       position.setCharacter(errorLineChar)

--- a/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
+++ b/server/src/test/scala/com/ossum/riddl/lsp/server/RiddlLSPTextDocumentSpec.scala
@@ -16,6 +16,7 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.jdk.CollectionConverters.*
 import scala.jdk.FutureConverters.*
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class RiddlLSPTextDocumentSpec
     extends AnyWordSpec
@@ -142,20 +143,31 @@ class RiddlLSPTextDocumentSpec
       }
     }
 
-    /* TODO: Finish these tests immediately
-    "successfully change everythingOneError.riddl" in new ChangeOneErrorFileSpec {}
+    "successfully change everythingOneError.riddl, fixing the error" in new ChangeOneErrorFileSpec
+      with CompletionRequestSpec {
+      position.setLine(errorLine)
+      position.setCharacter(errorCharOnLine)
+      requestCompletion()
 
-    "successfully save everythingOneError.riddl" in new ChangeOneErrorFileSpec {
-      val saveNotification = new DidSaveTextDocumentParams()
-      saveNotification.setTextDocument(textDocumentIdentifier)
-      service.didSave(saveNotification)
+      completionResultF.asScala.failed.futureValue mustBe a[Throwable]
+      completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document has no errors"
     }
 
-    "successfully change empty.riddl" in new ChangeEmptyFileSpec {}
+    "successfully change empty.riddl, expecting 2 errors" in new ChangeEmptyFileSpec
+      with CompletionRequestSpec {
+      position.setLine(errorLine)
+      position.setCharacter(errorLineChar)
+      requestCompletion()
 
-     */
+      whenReady(completionResultF.asScala) { completionList =>
+        completionList.isRight mustBe true
+        completionList.getRight.getItems.asScala.length mustEqual 1
+        completionList.getRight.getItems.asScala.head.getDetail mustEqual
+          """Expected one of (end-of-input | whitespace after keyword)"""
+      }
+    }
 
-    "successfully save empty.riddl" in new ChangeEmptyFileSpec
+    "successfully save empty.riddl" in new OpenEmptyFileSpec
       with CompletionRequestSpec
       with DiagnosticRequestSpec {
 
@@ -166,6 +178,9 @@ class RiddlLSPTextDocumentSpec
       completionResultF.asScala.failed.futureValue.getMessage mustEqual "Document is empty"
 
       // Need to actually change the file before running the test
+      val textChange: String =
+        """domain New {}""".stripMargin
+
       var p = new java.io.PrintWriter(new File(emptyDocURI))
       try { p.println(textChange) }
       finally { p.close() }


### PR DESCRIPTION
Uncomments the last 2 commented out tests to ensure `didChange` retains changes well
- `successfully change everythingOneError.riddl, fixing the error`
- `successfully change empty.riddl, expecting an error`